### PR TITLE
run-task.py should exit with correct code

### DIFF
--- a/src/run-task.py
+++ b/src/run-task.py
@@ -129,3 +129,7 @@ if 'exitCode' in running_task['tasks'][0]['containers'][0]:
     print('Exit code:      %s' %running_task['tasks'][0]['containers'][0]['exitCode'])
 if 'reason' in running_task['tasks'][0]['containers'][0]:
     print('Reason:         %s' %running_task['tasks'][0]['containers'][0]['reason'])
+
+# exit with task exit code
+if 'exitCode' in running_task['tasks'][0]['containers'][0]:
+    exit(running_task['tasks'][0]['containers'][0]['exitCode'])


### PR DESCRIPTION
We are having the issue where task exit with non zero value but the script still exit with code 0. I believe this isn't the correct behaviour as in most of case we need to fail the pipeline if the task is failed. If somehow developers need to keep the pipeline running they should catch that exit code and continue. 

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...